### PR TITLE
Change add plants route to ensure correct userid entered

### DIFF
--- a/backend/models/plant.model.js
+++ b/backend/models/plant.model.js
@@ -4,7 +4,11 @@ const mongoose = require("mongoose");
 
 const plantSchema = new Schema(
   {
-    userid: { type: String, required: false },
+    userid: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true
+    },
     nickname: { type: String, required: true },
     type: { type: String, required: true },
     wateringFrequency: { type: Number, required: false },


### PR DESCRIPTION
Plants now belong to Users in the schema but currently users must know their userid when adding plants (the add plants form requires it). Need to find a way to enter this automatically or store this info somewhere and remove it from the add plants form.